### PR TITLE
Updated RegExp matcher to return the matched string

### DIFF
--- a/index.js
+++ b/index.js
@@ -49,7 +49,8 @@ function stringMatches(str, search) {
 		return (str.indexOf(search) !== -1) ? search : false;
 	}
 	if (search instanceof RegExp) {
-		return (str.match(search)) ? search : false;
+		// if the RegExp is found, return the matched string
+		return (search.test(str)) ? search.exec(str)[0] : false;
 	}
 
 	for (var i = 0; i < search.length; i++) {

--- a/test.js
+++ b/test.js
@@ -49,6 +49,16 @@ describe('gulp-contains tests', function () {
 		}, /contains "notfound"/);
 	});
 
+	it('should return the string matched by a RegExp', function () {
+		should.throws(function () {
+			var stream = contains(/should .* matched string/);
+
+			stream.write(new gutil.File({
+				contents: new Buffer('this should return the matched string from the RegExp')
+			}));
+		}, /contains "should return the matched string"/);
+	});
+
 	it('should accept array of regexps to find', function () {
 		should.throws(function () {
 			var stream = contains([/(notfound)/, /(somethingelse)/]);


### PR DESCRIPTION
I like the functionality provided by gulp-contains when searching file content with a regular expression. It is somewhat useful to tell me that the regular expression was found, but this patch set provides even more value by returning the string that was found to match the regular expression.
